### PR TITLE
MM-51701: Show lock output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,8 @@ require github.com/jackc/pgx/v5 v5.3.1
 require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
+	github.com/jackc/puddle/v2 v2.2.0 // indirect
 	golang.org/x/crypto v0.6.0 // indirect
+	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/text v0.7.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a h1:bbPeKD0xmW/
 github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
 github.com/jackc/pgx/v5 v5.3.1 h1:Fcr8QJ1ZeLi5zsPZqQeUZhNhxfkkKBOgJuYkJHoBOtU=
 github.com/jackc/pgx/v5 v5.3.1/go.mod h1:t3JDKnCBlYIc0ewLF0Q7B8MXmoIaBOZj/ic7iHozM/8=
+github.com/jackc/puddle/v2 v2.2.0 h1:RdcDk92EJBuBS55nQMMYFXTxwstHug4jkhT5pq8VxPk=
+github.com/jackc/puddle/v2 v2.2.0/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -14,6 +16,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 golang.org/x/crypto v0.6.0 h1:qfktjS5LUO+fFKeJXZ+ikTRijMmljikvG68fpMMruSc=
 golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/text v0.7.0 h1:4BRB4x83lYWy72KwLD/qYDuTu7q9PjSagHvijDw7cLo=
 golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ func main() {
 	}
 	defer pool.Close()
 
-	_, err = pool.Exec(context.Background(), "CREATE EXTENSION IF NOT EXISTS pg_stat_statements;")
+	_, err = pool.Exec(context.TODO(), "CREATE EXTENSION IF NOT EXISTS pg_stat_statements;")
 	if err != nil {
 		logger.Println(err)
 		return
@@ -86,7 +86,7 @@ func main() {
 			continue
 		}
 
-		_, err = pool.Exec(context.Background(), "SELECT pg_stat_statements_reset();")
+		_, err = pool.Exec(context.TODO(), "SELECT pg_stat_statements_reset();")
 		if err != nil {
 			logger.Println(err)
 			return
@@ -126,7 +126,7 @@ func main() {
 				case <-quit:
 					return
 				case <-ticker.C:
-					rows, err := pool.Query(context.Background(), `SELECT locktype, relation::regclass, mode, granted
+					rows, err := pool.Query(context.TODO(), `SELECT locktype, relation::regclass, mode, granted
 				FROM pg_catalog.pg_locks l
 				LEFT JOIN pg_catalog.pg_database db ON db.oid = l.database
 				JOIN pg_class c ON l.relation=c.oid
@@ -138,14 +138,14 @@ func main() {
 					var lockType, relation, mode string
 					var granted bool
 					pgx.ForEachRow(rows, []any{&lockType, &relation, &mode, &granted}, func() error {
-						lockMap[lockType+"-"+relation+"-"+mode+"-"+fmt.Sprint(granted)] = true
+						lockMap[fmt.Sprintf("%s-%s-%s-%t", lockType, relation, mode, granted)] = true
 						return nil
 					})
 				}
 			}
 		}()
 
-		_, err = pool.Exec(context.Background(), fmt.Sprintf("%s", buf))
+		_, err = pool.Exec(context.TODO(), fmt.Sprintf("%s", buf))
 		if err != nil {
 			logger.Println(err)
 			continue


### PR DESCRIPTION
Example run
```
Starting migration:                        000106_fileinfo_channelid.up.sql---------------------------------------------
LOCKS:
LOCK TYPE: relation, RELATION: fileinfo, MODE: RowExclusiveLock, GRANTED: true
LOCK TYPE: relation, RELATION: posts, MODE: AccessShareLock, GRANTED: true
LOCK TYPE: relation, RELATION: fileinfo, MODE: ShareLock, GRANTED: true
LOCK TYPE: relation, RELATION: fileinfo, MODE: AccessExclusiveLock, GRANTED: true
QUERY:  UPDATE fileinfo SET channelid = posts.channelid FROM posts WHERE fileinfo.channelid IS NULL AND fileinfo.postid = posts.id
EXEC TIME: 0.012882 ms, ROWS AFFECTED: 0
QUERY:  CREATE INDEX IF NOT EXISTS idx_fileinfo_channel_id_create_at ON fileinfo(channelid, createat)
EXEC TIME: 2088.678447 ms, ROWS AFFECTED: 0
QUERY:  SELECT locktype, relation::regclass, mode, granted
                                FROM pg_catalog.pg_locks l
                                LEFT JOIN pg_catalog.pg_database db ON db.oid = l.database
                                JOIN pg_class c ON l.relation=c.oid
                                WHERE (db.datname = current_database() OR db.datname IS NULL) AND c.relkind=$1 AND NOT pid = pg_backend_pid() AND locktype=$2
EXEC TIME: 0.793934 ms, ROWS AFFECTED: 9
QUERY:  ALTER TABLE fileinfo ADD COLUMN IF NOT EXISTS channelid varchar(26)
EXEC TIME: 0.829388 ms, ROWS AFFECTED: 0
```

https://mattermost.atlassian.net/browse/MM-51701
